### PR TITLE
Show framed desktop wallpaper even if it has square dimensions

### DIFF
--- a/dotnet/RAWeb.Server.Utilities/src/WorkspaceBuilder.cs
+++ b/dotnet/RAWeb.Server.Utilities/src/WorkspaceBuilder.cs
@@ -694,7 +694,10 @@ public class WorkspaceBuilder {
         // if the icon is not a square, use the default icon
         // or treat it as wallpaper if the mode is set to "wallpaper"
         var frame = "";
-        if (iconWidth != iconHeight) {
+        if (mode == IconElementsMode.Wallpaper) {
+            frame = "&amp;frame=pc";
+        }
+        else if (iconWidth != iconHeight) {
             // if the icon is not a square, use the default icon instead
             if (mode == IconElementsMode.Icon) {
                 iconPath = defaultIconPath;
@@ -705,11 +708,6 @@ public class WorkspaceBuilder {
                         iconHeight = image.Height;
                     }
                 }
-            }
-
-            // or, if the mode is set to "wallpaper", we will allow non-square icons
-            if (mode == IconElementsMode.Wallpaper) {
-                frame = "&amp;frame=pc";
             }
         }
 


### PR DESCRIPTION
When showing desktops as icons, RAWeb places the desktop wallpaper inside a PC frame (similar to the This PC icon on Windows). However, if the wallpaper had the same width and height, RAWeb did not place the wallpaper in a frame. With this change, wallpaper that is requested to be framed will always be framed, even if the wallpaper has the same width and height.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed wallpaper mode to consistently apply frames to all icons, regardless of size or dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->